### PR TITLE
8 add delivery notification options

### DIFF
--- a/PoshMailKit/Internals/DeliveryNotificationOptions.cs
+++ b/PoshMailKit/Internals/DeliveryNotificationOptions.cs
@@ -1,0 +1,11 @@
+﻿namespace PoshMailKit.Internals
+{
+    public enum DeliveryNotificationOptions
+    {
+        None,
+        OnSuccess,
+        OnFailure,
+        Delay,
+        Never = 134217728,
+    }
+}

--- a/PoshMailKit/Internals/PMKSmtpClient.cs
+++ b/PoshMailKit/Internals/PMKSmtpClient.cs
@@ -1,11 +1,6 @@
 ﻿using MailKit;
 using MailKit.Net.Smtp;
 using MimeKit;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace PoshMailKit.Internals
 {

--- a/PoshMailKit/Internals/PMKSmtpClient.cs
+++ b/PoshMailKit/Internals/PMKSmtpClient.cs
@@ -1,0 +1,21 @@
+﻿using MailKit;
+using MailKit.Net.Smtp;
+using MimeKit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PoshMailKit.Internals
+{
+    public class PMKSmtpClient : SmtpClient
+    {
+		public DeliveryStatusNotification? DeliveryStatusNotification { get; set; }
+
+		protected override DeliveryStatusNotification? GetDeliveryStatusNotifications(MimeMessage message, MailboxAddress mailbox)
+		{
+			return DeliveryStatusNotification;
+		}
+	}
+}

--- a/PoshMailKit/Internals/SmtpProcessor.cs
+++ b/PoshMailKit/Internals/SmtpProcessor.cs
@@ -13,12 +13,16 @@ namespace PoshMailKit.Internals
         public DeliveryStatusNotification? Notification { get; set; }
         public SecureSocketOptions SecureSocketOptions { get; set; }
 
-        public SmtpProcessor()
+        public SmtpProcessor(PMKSmtpClient client)
         {
-            Client = new PMKSmtpClient();
+            Client = client;
             SmtpPort = 25;
             SecureSocketOptions = SecureSocketOptions.None;
         }
+
+        public SmtpProcessor()
+            : this(new PMKSmtpClient())
+        { }
 
         public void SendMailMessage()
         {

--- a/PoshMailKit/Internals/SmtpProcessor.cs
+++ b/PoshMailKit/Internals/SmtpProcessor.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MimeKit;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using MailKit;
+
+namespace PoshMailKit.Internals
+{
+    public class SmtpProcessor
+    {
+        public string SmtpServer { get; set; }
+        public int SmtpPort { get; set; }
+        public MimeMessage Message { get; set; }
+        public PMKSmtpClient Client { get; set; }
+        public DeliveryStatusNotification? Notification { get; set; }
+        public SecureSocketOptions SecureSocketOptions { get; set; }
+
+        public SmtpProcessor()
+        {
+            Client = new PMKSmtpClient();
+            SmtpPort = 25;
+            SecureSocketOptions = SecureSocketOptions.None;
+        }
+
+        public void SendMailMessage()
+        {
+            Client.DeliveryStatusNotification = Notification;
+            if (SmtpServer != null && Message != null)
+            {
+                Client.Connect(SmtpServer, SmtpPort, SecureSocketOptions);
+                Client.Send(Message);
+                Client.Disconnect(true);
+            }
+        }
+
+        // Leaving here temporarily while implementing more functionality
+        /*public static void SendMailMessage(string smtpServer, int port, MimeMessage message)
+        {
+            using (PMKSmtpClient client = new PMKSmtpClient())
+            {
+                //SecureSocketOptions secureSocketOptions = SecureSocketOptions.None;
+                //client.Connect(SmtpServer, Port, secureSocketOptions);
+
+                client.Connect(smtpServer, port, SecureSocketOptions.None);                
+
+                // Note: only needed if the SMTP server requires authentication
+                //client.Authenticate("joey", "password");
+
+                client.Send(message);
+                client.Disconnect(true);
+            }
+        }*/
+    }
+}

--- a/PoshMailKit/Internals/SmtpProcessor.cs
+++ b/PoshMailKit/Internals/SmtpProcessor.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using MimeKit;
-using MailKit.Net.Smtp;
+﻿using MimeKit;
 using MailKit.Security;
 using MailKit;
 

--- a/PoshMailKit/PoshMailKit.csproj
+++ b/PoshMailKit/PoshMailKit.csproj
@@ -65,6 +65,8 @@
     <Compile Include="Internals\MessageBuilder.cs" />
     <Compile Include="Internals\MailPriority.cs" />
     <Compile Include="Internals\MimeMap.cs" />
+    <Compile Include="Internals\PMKSmtpClient.cs" />
+    <Compile Include="Internals\SmtpProcessor.cs" />
     <Compile Include="SendMKMailMessage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/PoshMailKit/PoshMailKit.csproj
+++ b/PoshMailKit/PoshMailKit.csproj
@@ -60,6 +60,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Internals\DeliveryNotificationOptions.cs" />
     <Compile Include="Internals\Encoding.cs" />
     <Compile Include="Internals\FileProcessor.cs" />
     <Compile Include="Internals\MessageBuilder.cs" />

--- a/PoshMailKit/SendMKMailMessage.cs
+++ b/PoshMailKit/SendMKMailMessage.cs
@@ -103,7 +103,14 @@ namespace PoshMailKit
             MailMessage.NewMailBody(BodyFormat, CharsetEncoding, Body, ContentTransferEncoding);
             MailMessage.AddAttachments(FilesToAttach);
 
-            SendMailMessage();
+            SmtpProcessor processor = new SmtpProcessor()
+            {
+                SmtpServer = SmtpServer,
+                SmtpPort = Port,
+                Message = MailMessage.Message,
+            };
+
+            processor.SendMailMessage();
         }
 
         private void ProcessParameterSets()
@@ -211,22 +218,6 @@ namespace PoshMailKit
                     CharsetEncoding = System.Text.Encoding.UTF32;
                     ContentTransferEncoding = ContentEncoding.Base64;
                     break;
-            }
-        }
-
-        private void SendMailMessage()
-        {
-            using (SmtpClient client = new SmtpClient())
-            {
-                //SecureSocketOptions secureSocketOptions = SecureSocketOptions.None;
-                //client.Connect(SmtpServer, Port, secureSocketOptions);
-                client.Connect(SmtpServer, Port, SecureSocketOptions.None);
-
-                // Note: only needed if the SMTP server requires authentication
-                //client.Authenticate("joey", "password");
-
-                client.Send(MailMessage.Message);
-                client.Disconnect(true);
             }
         }
     }

--- a/PoshMailKit/SendMKMailMessage.cs
+++ b/PoshMailKit/SendMKMailMessage.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Management.Automation;
 using MimeKit;
-using MailKit.Net.Smtp;
-using MailKit.Security;
 using MimeKit.Text;
 using PoshMailKit.Internals;
 using MailKit;

--- a/PoshMailKitTest/Internals/MessageBuilderTests.cs
+++ b/PoshMailKitTest/Internals/MessageBuilderTests.cs
@@ -2,7 +2,6 @@
 using MimeKit.Text;
 using Moq;
 using PoshMailKit.Internals;
-using System;
 using System.Linq;
 using System.Collections.Generic;
 using Xunit;

--- a/PoshMailKitTest/Internals/SmtpProcessorTests.cs
+++ b/PoshMailKitTest/Internals/SmtpProcessorTests.cs
@@ -2,7 +2,6 @@
 using MailKit;
 using Moq;
 using PoshMailKit.Internals;
-using System;
 using Xunit;
 using System.Threading;
 
@@ -17,24 +16,20 @@ namespace PoshMailKitTest.Internals
             mockRepository = new MockRepository(MockBehavior.Strict);
         }
 
-        private SmtpProcessor CreateSmtpProcessor()
+        private SmtpProcessor CreateSmtpProcessor(PMKSmtpClient mockClient)
         {
-            return new SmtpProcessor();
+            return new SmtpProcessor(mockClient);
         }
 
         [Fact]
         public void SendMailMessage_MissingSmtpServer_DoesNotSend()
         {
             // Arrange
-            var sendMethodWasCalled = false;
-            var mockSmptClient = new Mock<PMKSmtpClient>();
-            mockSmptClient.Setup(c => c.Send(It.IsAny<MimeMessage>(), It.IsAny<CancellationToken>(), It.IsAny<ITransferProgress>())).
-                Callback(() => sendMethodWasCalled = true);
-
+            var mockSmtpClient = new Mock<PMKSmtpClient>();
             var mockMimeMessage = new Mock<MimeMessage>();
-            var message = new MimeMessage();
 
-            var smtpProcessor = CreateSmtpProcessor();
+            var message = new MimeMessage();
+            var smtpProcessor = CreateSmtpProcessor(mockSmtpClient.Object);
 
             smtpProcessor.Message = message;
 
@@ -42,8 +37,54 @@ namespace PoshMailKitTest.Internals
             smtpProcessor.SendMailMessage();
 
             // Assert
-            Assert.False(sendMethodWasCalled);
+            mockSmtpClient.Verify(mock =>
+                mock.Send(It.IsAny<MimeMessage>(), It.IsAny<CancellationToken>(), It.IsAny<ITransferProgress>()), Times.Never());
 
+            mockRepository.VerifyAll();
+        }
+
+        [Fact]
+        public void SendMailMessage_MissingMessage_DoesNotSend()
+        {
+            // Arrange
+            var mockSmtpClient = new Mock<PMKSmtpClient>();
+
+            var smtpServer = "test.smtp.local";
+            var smtpProcessor = CreateSmtpProcessor(mockSmtpClient.Object);
+
+            smtpProcessor.SmtpServer = smtpServer;
+
+            // Act
+            smtpProcessor.SendMailMessage();
+
+            // Assert
+            mockSmtpClient.Verify(mock =>
+                mock.Send(It.IsAny<MimeMessage>(), It.IsAny<CancellationToken>(), It.IsAny<ITransferProgress>()), Times.Never());
+
+            mockRepository.VerifyAll();
+        }
+
+        [Fact]
+        public void SendMailMessage_HasServerAndMessage_Sends()
+        {
+            // Arrange
+            var mockSmtpClient = new Mock<PMKSmtpClient>();
+            var mockMimeMessage = new Mock<MimeMessage>();
+
+            var message = new MimeMessage();
+            var smtpServer = "test.smtp.local";
+            var smtpProcessor = CreateSmtpProcessor(mockSmtpClient.Object);
+
+            smtpProcessor.Message = message;
+            smtpProcessor.SmtpServer = smtpServer;
+
+            // Act
+            smtpProcessor.SendMailMessage();
+
+            // Assert
+            mockSmtpClient.Verify(mock => 
+                mock.Send(It.IsAny<MimeMessage>(), It.IsAny<CancellationToken>(), It.IsAny<ITransferProgress>()));
+            
             mockRepository.VerifyAll();
         }
     }

--- a/PoshMailKitTest/Internals/SmtpProcessorTests.cs
+++ b/PoshMailKitTest/Internals/SmtpProcessorTests.cs
@@ -1,0 +1,50 @@
+﻿using MimeKit;
+using MailKit;
+using Moq;
+using PoshMailKit.Internals;
+using System;
+using Xunit;
+using System.Threading;
+
+namespace PoshMailKitTest.Internals
+{
+    public class SmtpProcessorTests
+    {
+        private MockRepository mockRepository;
+
+        public SmtpProcessorTests()
+        {
+            mockRepository = new MockRepository(MockBehavior.Strict);
+        }
+
+        private SmtpProcessor CreateSmtpProcessor()
+        {
+            return new SmtpProcessor();
+        }
+
+        [Fact]
+        public void SendMailMessage_MissingSmtpServer_DoesNotSend()
+        {
+            // Arrange
+            var sendMethodWasCalled = false;
+            var mockSmptClient = new Mock<PMKSmtpClient>();
+            mockSmptClient.Setup(c => c.Send(It.IsAny<MimeMessage>(), It.IsAny<CancellationToken>(), It.IsAny<ITransferProgress>())).
+                Callback(() => sendMethodWasCalled = true);
+
+            var mockMimeMessage = new Mock<MimeMessage>();
+            var message = new MimeMessage();
+
+            var smtpProcessor = CreateSmtpProcessor();
+
+            smtpProcessor.Message = message;
+
+            // Act
+            smtpProcessor.SendMailMessage();
+
+            // Assert
+            Assert.False(sendMethodWasCalled);
+
+            mockRepository.VerifyAll();
+        }
+    }
+}

--- a/PoshMailKitTest/PoshMailKitTest.csproj
+++ b/PoshMailKitTest/PoshMailKitTest.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MailKit" Version="3.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="MimeKit" Version="3.1.1" />
     <PackageReference Include="Moq" Version="4.17.2" />


### PR DESCRIPTION
* Added the SmtpProcessor class and moved the SendMailMessage code to it
* Overrode the MailKit.Net.Smtp.SmtpClient class to inject a handler for DeliveryStatusNotification
* Added Legacy and Modern options for delivery status notifications
  * -DeliveryNotificationOption (legacy)
  * -DeliveryStatusNotification (modern)
* Added tests for the new SmtpProcessor class

Closes #8 