### PR TITLE
Email address enhancements

### DIFF
--- a/PoshMailKit/Internals/MessageBuilder.cs
+++ b/PoshMailKit/Internals/MessageBuilder.cs
@@ -1,4 +1,4 @@
-using MimeKit;
+﻿using MimeKit;
 using MimeKit.Text;
 using System.Collections.Generic;
 
@@ -58,7 +58,9 @@ namespace PoshMailKit.Internals
 
         public MailboxAddress GetMailboxAddressObj(string email)
         {
-            return new MailboxAddress("", email);
+            MailboxAddress mailboxAddress = new MailboxAddress("", email);
+            var _ = ((System.Net.Mail.MailAddress)mailboxAddress);
+            return mailboxAddress;
         }
 
         public void AddAttachments(List<MimePart> filesToAttach)

--- a/PoshMailKit/Internals/MessageBuilder.cs
+++ b/PoshMailKit/Internals/MessageBuilder.cs
@@ -1,4 +1,4 @@
-﻿using MimeKit;
+using MimeKit;
 using MimeKit.Text;
 using System.Collections.Generic;
 
@@ -56,7 +56,7 @@ namespace PoshMailKit.Internals
             message = new MimeMessage();
         }
 
-        private MailboxAddress GetMailboxAddressObj(string email)
+        public MailboxAddress GetMailboxAddressObj(string email)
         {
             return new MailboxAddress("", email);
         }

--- a/PoshMailKit/Internals/MessageBuilder.cs
+++ b/PoshMailKit/Internals/MessageBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using MimeKit;
 using MimeKit.Text;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace PoshMailKit.Internals
 {
@@ -10,6 +11,8 @@ namespace PoshMailKit.Internals
         private MimeMessage message { get; set; }
         private TextPart TextMailBody { get; set; }
         private Multipart MultipartMailBody { get; set; }
+
+        private static Regex EmailWithDisplayNamePattern = new Regex("^(?<DisplayName>[^<]+)<(?<Email>[^>]+)>$");
 
         // Setters
         public string Subject { set => message.Subject = value; }
@@ -58,7 +61,15 @@ namespace PoshMailKit.Internals
 
         public MailboxAddress GetMailboxAddressObj(string email)
         {
-            MailboxAddress mailboxAddress = new MailboxAddress("", email);
+            string displayName = "";
+            var regexResult = EmailWithDisplayNamePattern.Match(email);
+            if (regexResult.Success)
+            {
+                displayName = regexResult.Groups["DisplayName"].Value.Trim();
+                email = regexResult.Groups["Email"].Value;
+            }
+
+            MailboxAddress mailboxAddress = new MailboxAddress(displayName, email);
             var _ = ((System.Net.Mail.MailAddress)mailboxAddress);
             return mailboxAddress;
         }

--- a/PoshMailKitTest/Internals/MessageBuilderTests.cs
+++ b/PoshMailKitTest/Internals/MessageBuilderTests.cs
@@ -5,6 +5,7 @@ using PoshMailKit.Internals;
 using System.Linq;
 using System.Collections.Generic;
 using Xunit;
+using System;
 
 namespace PoshMailKitTest.Internals
 {
@@ -231,6 +232,65 @@ namespace PoshMailKitTest.Internals
                 $"Message body: actual '{message.TextBody}', expected '{body}'");
             Assert.True(bodyTextPart.ContentTransferEncoding == contentTransferEncoding,
                 $"ContentTransferEncoding: actual '{bodyTextPart.ContentTransferEncoding}', expected '{contentTransferEncoding}'");
+
+            mockRepository.VerifyAll();
+        }
+
+        [Fact]
+        public void GetMailboxAddressObj_ValidEmailAddressOnly_ReturnsSimpleEmailAddress()
+        {
+            // Arrange
+            var messageBuilder = CreateMessageBuilder();
+            var emailAddress = "test@email.com";
+
+            // Act
+            var mailboxAddressObj = messageBuilder.GetMailboxAddressObj(emailAddress);
+
+            // Assert
+            Assert.Equal(mailboxAddressObj.Address, emailAddress);
+
+            mockRepository.VerifyAll();
+        }
+
+        [Fact]
+        public void GetMailboxAddressObj_InvalidEmailAddress_ThrowsFormatExceptionError()
+        {
+            // Arrange
+            var messageBuilder = CreateMessageBuilder();
+            var emailAddress = "test?email.com";
+
+            // Act & Assert
+            try
+            {
+                var _ = messageBuilder.GetMailboxAddressObj(emailAddress);
+                Assert.False(true,
+                    $"Exception expected but not thrown");
+            }
+            catch(Exception e)
+            {
+                Assert.True(e is FormatException,
+                    $"FormatException expected, actual exception thrown: {e.GetType()}");
+            }
+
+            mockRepository.VerifyAll();
+        }
+
+        [Fact]
+        public void GetMailboxAddressObj_ValidEmailAddressWithDisplayName_ReturnsCompoundEmailAddress()
+        {
+            // Arrange
+            var messageBuilder = CreateMessageBuilder();
+            var emailAddress = "test@email.com";
+            var displayName = "Testy McTesterson";
+
+            var compoundAddress = $"{displayName} <{emailAddress}>";
+
+            // Act
+            var mailboxAddressObj = messageBuilder.GetMailboxAddressObj(compoundAddress);
+
+            // Assert
+            Assert.Equal(mailboxAddressObj.Address, emailAddress);
+            Assert.Equal(mailboxAddressObj.Name, displayName);
 
             mockRepository.VerifyAll();
         }


### PR DESCRIPTION
* Added support for display names in address fields (resolves #20 )
* Added validation for email addresses (resolves #21 )
  * Note: this behavior is slightly different from Send-MailMessage: in that, if one email address was invalid, it would attempt to proceed with the remainder, which I feel is a bad way to handle this, so I'm going to handle it by failing entirely and not attempting to send an email with partial recipients.  If the classic behavior is desired, I may add it back in as part of the Legacy behaviors, but only as Legacy.