### PR TITLE
39 bugfix network attachments

### DIFF
--- a/PoshMailKit/Internals/FileProcessor.cs
+++ b/PoshMailKit/Internals/FileProcessor.cs
@@ -9,7 +9,7 @@ namespace PoshMailKit.Internals
     {
         public string WorkingDirectory { get; set; }
         private readonly IFileSystem FileSystem;
-        private readonly Regex pathPattern = new Regex(@"^[a-zA-Z]:");
+        private readonly Regex pathPattern = new Regex(@"^([a-zA-Z]:|//|\\\\)");
 
         public FileProcessor(string workingDirectory, IFileSystem fileSystem)
         {
@@ -26,7 +26,7 @@ namespace PoshMailKit.Internals
             if (!pathPattern.IsMatch(fileName))
                 return Path.GetFullPath($"{WorkingDirectory}\\{fileName}");
             else
-                return fileName;
+                return Path.GetFullPath(fileName);
         }
 
         public MimePart GetFileMimePart(string fileName, ContentDispositionType contentDisposition, string label = null)

--- a/PoshMailKitTest/Internals/FileProcessorTests.cs
+++ b/PoshMailKitTest/Internals/FileProcessorTests.cs
@@ -33,12 +33,88 @@ namespace PoshMailKitTest.Internals
         }
 
         [Fact]
-        public void GetFullPathName_FileNameOnly_ReturnsFullPath()
+        public void GetFullPathName_FileFullPath_ReturnsFullPath()
         {
             // Arrange
             var fileName = @"C:\test\tmp\test.txt";
             var filePath = @"C:\test\tmp";
             var expectedReturnPath = @"C:\test\tmp\test.txt";
+
+            var fileProcessor = CreateFileProcessor(filePath, GetMockFileSystem());
+
+            // Act
+            var result = fileProcessor.GetFullPathName(fileName);
+
+            // Assert
+            Assert.True(result == expectedReturnPath,
+                $"Actual: {result}, expected: {expectedReturnPath}");
+            mockRepository.VerifyAll();
+        }
+
+        [Fact]
+        public void GetFullPathName_FileFullNetworkPath_ReturnsFullPath()
+        {
+            // Arrange
+            var fileName = @"\\srv\test\tmp\test.txt";
+            var filePath = @"\\srv\test\tmp";
+            var expectedReturnPath = @"\\srv\test\tmp\test.txt";
+
+            var fileProcessor = CreateFileProcessor(filePath, GetMockFileSystem());
+
+            // Act
+            var result = fileProcessor.GetFullPathName(fileName);
+
+            // Assert
+            Assert.True(result == expectedReturnPath,
+                $"Actual: {result}, expected: {expectedReturnPath}");
+            mockRepository.VerifyAll();
+        }
+
+        [Fact]
+        public void GetFullPathName_FileFullNetworkPathMixedPathSeparators_ReturnsFullPath()
+        {
+            // Arrange
+            var fileName = @"\\srv\test/tmp/test.txt";
+            var filePath = @"\\srv\test\tmp";
+            var expectedReturnPath = @"\\srv\test\tmp\test.txt";
+
+            var fileProcessor = CreateFileProcessor(filePath, GetMockFileSystem());
+
+            // Act
+            var result = fileProcessor.GetFullPathName(fileName);
+
+            // Assert
+            Assert.True(result == expectedReturnPath,
+                $"Actual: {result}, expected: {expectedReturnPath}");
+            mockRepository.VerifyAll();
+        }
+
+        [Fact]
+        public void GetFullPathName_FileRelativeNetworkPath_ReturnsFullPath()
+        {
+            // Arrange
+            var fileName = @"..\test.txt";
+            var filePath = @"\\srv\test\tmp";
+            var expectedReturnPath = @"\\srv\test\test.txt";
+
+            var fileProcessor = CreateFileProcessor(filePath, GetMockFileSystem());
+
+            // Act
+            var result = fileProcessor.GetFullPathName(fileName);
+
+            // Assert
+            Assert.True(result == expectedReturnPath,
+                $"Actual: {result}, expected: {expectedReturnPath}");
+            mockRepository.VerifyAll();
+        }
+
+        [Fact]
+        public void GetFullPathName_FileRelativeNetworkPathMixedPathSeparators_ReturnsFullPath()
+        {
+            // Arrange
+            var fileName = @"../test.txt";
+            var filePath = @"\\srv\test\tmp";
+            var expectedReturnPath = @"\\srv\test\test.txt";
 
             var fileProcessor = CreateFileProcessor(filePath, GetMockFileSystem());
 
@@ -71,7 +147,7 @@ namespace PoshMailKitTest.Internals
         }
 
         [Fact]
-        public void GetFullPathName_FileFullPath_ReturnsFullPath()
+        public void GetFullPathName_FileNameOnly_ReturnsFullPath()
         {
             // Arrange
             var fileName = "test.txt";


### PR DESCRIPTION
Issue was with RegEx only targeting local paths; added root path markers for network paths.

This will probably be an issue on Linux as well, so I should look into that.