### PR TITLE
Remove .exe extension from pwsh in PostBuild

### DIFF
--- a/PoshMailKit/PoshMailKit.csproj
+++ b/PoshMailKit/PoshMailKit.csproj
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  
+
   <PropertyGroup>
     <ProjectGuid>{5630C3F8-B365-46F3-8B63-3ED9C193C45A}</ProjectGuid>
     <ImplicitUsings>enable</ImplicitUsings>
     <!-- <Nullable>enable</Nullable> -->
     <TargetFramework>net6.0</TargetFramework>
     <Authors>The PowerShell Bear</Authors>
-	<VersionPrefix>2.0.0</VersionPrefix>
-	<VersionSuffix>alpha4</VersionSuffix>
+    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionSuffix>alpha4</VersionSuffix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
-	<Version>$(VersionPrefix)-$(VersionSuffix)</Version>
+    <Version>$(VersionPrefix)-$(VersionSuffix)</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/poshcodebear/PoshMailKit</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -21,34 +21,34 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="MailKit" Version="3.1.1" />
     <PackageReference Include="System.IO.Abstractions" Version="16.1.24" />
     <PackageReference Include="System.Management.Automation" Version="7.2.2" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <None Include="..\README.md">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
-    
+
     <None Include="packages.config" />
-    
+
     <None Include="ModuleMembers\PoshMailKit.psd1">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    
+
     <None Include="ModuleMembers\en-US\PoshMailKit.dll-help.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    
+
     <None Include="ModuleMembers\en-US\about_PoshMailKit.help.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  
+
   <ItemGroup>
     <None Update="Build\BuildConfig.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -57,9 +57,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  
+
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="pwsh -C &quot;&amp; '$(TargetDir)\Build\BuildScript.ps1'&quot;" />
   </Target>
-  
+
 </Project>

--- a/PoshMailKit/PoshMailKit.csproj
+++ b/PoshMailKit/PoshMailKit.csproj
@@ -59,7 +59,7 @@
   </ItemGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="pwsh.exe -C &quot;&amp; '$(TargetDir)\Build\BuildScript.ps1'&quot;" />
+    <Exec Command="pwsh -C &quot;&amp; '$(TargetDir)\Build\BuildScript.ps1'&quot;" />
   </Target>
   
 </Project>


### PR DESCRIPTION
Allows building in UNIX via .NET 6.
